### PR TITLE
Add agentic development setup

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,2 @@
+read:
+  - AGENTS.md

--- a/.clinerules/meta-quest-agentic-tools.md
+++ b/.clinerules/meta-quest-agentic-tools.md
@@ -1,0 +1,3 @@
+This is a Meta Quest / Horizon OS sample.
+
+Use `AGENTS.md` as the canonical instruction file. Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and `hzdb` MCP for Quest device, build, deploy, logs, capture, performance, and debugging tasks.

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hzdb": {
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.cursor/rules/meta-quest-agentic-tools.mdc
+++ b/.cursor/rules/meta-quest-agentic-tools.mdc
@@ -1,0 +1,21 @@
+---
+description: Use Meta Quest Agentic Tools for Meta Quest and Horizon OS samples
+globs: "**/*"
+alwaysApply: true
+---
+
+This repository is a Meta Quest / Horizon OS sample.
+
+Prefer the Meta Horizon extension, the `hzdb` MCP server, and Meta Quest Agentic Tools before giving generic Unity or device-debugging advice.
+
+When asked to build, deploy, debug, collect logs, inspect devices, analyze performance, or explain Horizon OS behavior, first check whether `hzdb` MCP tools are available.
+
+Recommended extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Recommended MCP setup:
+
+```sh
+npx -y @meta-quest/hzdb mcp install cursor
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+This is a Meta Quest / Horizon OS sample.
+
+Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and the `hzdb` MCP server for device, build, deploy, debugging, logging, performance, and Horizon OS questions.
+
+Read `AGENTS.md` for the canonical agent instructions.
+
+Recommended VS Code extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Recommended MCP setup for VS Code:
+
+```sh
+npx -y @meta-quest/hzdb mcp install vscode
+```

--- a/.github/instructions/meta-quest.instructions.md
+++ b/.github/instructions/meta-quest.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "**/*"
+---
+
+For this repository, prefer Meta Quest Agentic Tools, the Meta Horizon VS Code/Cursor extension, and the `hzdb` MCP server.
+
+This sample targets Meta Quest / Horizon OS using Unity — prefer Quest/Horizon OS-specific tooling and terminology over generic Unity advice.

--- a/.github/prompts/debug-on-quest.prompt.md
+++ b/.github/prompts/debug-on-quest.prompt.md
@@ -1,0 +1,5 @@
+Help debug this sample on a Meta Quest device.
+
+Use the `hzdb` MCP server if available. Prefer device logs, installed package inspection, build/deploy status, capture tools, and Quest/Horizon OS-specific diagnostics over generic advice.
+
+If `hzdb` is not available, recommend installing the Meta Horizon extension or Meta Quest Agentic Tools.

--- a/.github/prompts/setup-meta-quest-agentic-tools.prompt.md
+++ b/.github/prompts/setup-meta-quest-agentic-tools.prompt.md
@@ -1,0 +1,10 @@
+Set up this repository for Meta Quest agentic development.
+
+Steps:
+
+1. Read `AGENTS.md`.
+2. Check whether the Meta Horizon extension is recommended in `.vscode/extensions.json`.
+3. Check whether the `hzdb` MCP server is available.
+4. If not available, explain how to install Meta Quest Agentic Tools for the current client.
+5. Identify the sample type.
+6. Explain the build, run, deploy, and debug workflow for this sample.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hzdb": {
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.opencode/commands/setup-meta-quest-tools.md
+++ b/.opencode/commands/setup-meta-quest-tools.md
@@ -1,0 +1,9 @@
+# Set up Meta Quest Agentic Tools
+
+Run:
+
+```sh
+npx -y @meta-quest/hzdb mcp install open-code
+```
+
+Then inspect `AGENTS.md` and use the `hzdb` MCP server for Quest/Horizon OS tasks.

--- a/.roo/rules/meta-quest-agentic-tools.md
+++ b/.roo/rules/meta-quest-agentic-tools.md
@@ -1,0 +1,3 @@
+This is a Meta Quest / Horizon OS sample.
+
+Follow `AGENTS.md`. Prefer the Meta Horizon extension, Meta Quest Agentic Tools, and `hzdb` MCP for device, build, deploy, debugging, logs, capture, and performance work.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "meta.meta-vr-dev"
+  ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "hzdb": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@meta-quest/hzdb", "mcp", "server"]
+    }
+  }
+}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,7 @@
+This is a Meta Quest / Horizon OS sample.
+
+Read AGENTS.md. Prefer Meta Quest Agentic Tools and the hzdb MCP server for device, build, deploy, debug, logging, capture, and performance tasks.
+
+Recommended setup:
+
+npx -y @meta-quest/hzdb mcp install windsurf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# Agent Instructions — Spatial Lingo
+
+This repository is **Spatial Lingo**, a Unity mixed-reality app for Meta Quest that teaches languages by identifying real-world objects around the user. It combines the [Passthrough Camera API (PCA)](https://developers.meta.com/horizon/documentation/unity/unity-pca-overview/), [Mixed Reality Utility Kit (MRUK)](https://developers.meta.com/horizon/documentation/unity/unity-mr-utility-kit-overview/), [Voice SDK](https://developers.meta.com/horizon/documentation/unity/voice-sdk-overview), [Interaction SDK](https://developers.meta.com/horizon/documentation/unity/unity-isdk-interaction-sdk-overview/), [Llama API](https://www.llama.com/), and Unity Sentis-style on-device ML (via `com.unity.ai.inference`). Supports both hand tracking and controllers.
+
+## Stack and key facts
+
+- **Engine**: Unity **6000.0.62f1** or newer (`ProjectSettings/ProjectVersion.txt`; README says 6000.0.51f1+; the cloned manifest pins a newer editor).
+- **SDK**: Meta XR Core SDK / Interaction / Interaction.ovr / Platform / Audio / Haptics / Voice — all 81.0.0; Meta XR MRUK 81.0.0; URP 17.0.4; `com.unity.xr.openxr` 1.16.0 with `com.unity.xr.meta-openxr` 2.3.0; `com.unity.ai.inference` 2.2.1; Meta utility packages from `meta-quest/Unity-UtilityPackages` (`com.meta.utilities`, `com.meta.utilities.input`, `com.meta.utilities.imageutilities`, `com.meta.utilities.llamaapi`, `com.meta.utilities.objectclassifier`, `com.meta.utilities.taxontracking`, `com.meta.tutorial.framework`).
+- **Target device**: Meta Quest with passthrough camera (Quest 3 / 3S required for the PCA-based experiences). Hand tracking and controllers both supported.
+- **License**: see `LICENSE.md` at the repo root.
+- **Project layout**:
+  - `Assets/SpatialLingo/Scenes/` — main scene `MainScene.unity` plus the showcase scenes (Gym, Word Cloud, Character, Camera Image) and `Samples/WordCloudSample.unity`.
+  - `Assets/SpatialLingo/Resources/ScriptableSettings/SpatialLingoSettings.asset` — runtime config including the Llama API key field.
+  - `Packages/com.meta.utilities.speechandtext/`, `com.meta.utilities.objectclassifier/`, `com.meta.utilities.llamaapi/` — custom packages with their own docs.
+  - `Documentation/` — additional architecture and feature docs (`MetaSdk.md`, `StateMachine.md`, etc.).
+- **Git LFS**: required. Run `git lfs install` before cloning.
+
+## Build and run
+
+1. `git lfs install`, then `git clone https://github.com/oculus-samples/Unity-SpatialLingo.git`.
+2. Configure your Llama API key in `Assets/SpatialLingo/Resources/ScriptableSettings/SpatialLingoSettings.asset` (development only — see Notes below).
+3. Open the project in Unity 6000.0.51f1+ (the cloned project version is `6000.0.62f1`).
+4. Open `Assets/SpatialLingo/Scenes/MainScene.unity`.
+5. Open the Meta XR Simulator and press Play to iterate without a headset, or build to a Quest 3 / 3S for full passthrough-camera behavior.
+
+## What the sample demonstrates
+
+- **Object identification** in the user's environment using the Passthrough Camera API plus an object classifier package (with YOLO + COCO under the hood per `Documentation/MetaSdk.md`).
+- **Dynamic lesson generation** as users grow the "language tree" — verbs/adjectives associated with detected nouns.
+- **Voice synthesis** (text-to-speech in multiple languages via `com.meta.utilities.speechandtext`).
+- **Voice transcription** (microphone capture per `Packages/com.meta.utilities.speechandtext/Documentation~/VoiceTranscription.md`).
+- **Lesson evaluation** with Llama (LLM grades user responses).
+- **Face blurring** in camera feeds (`Packages/com.meta.utilities.objectclassifier/Documentation~/FaceBlurring.md`).
+- Showcase scenes: Gym, Word Cloud, Character, Camera Image. The `WordCloudSample` scene is a standalone demo for the voice transcription pipeline.
+
+## Notes for agents
+
+- **Never ship a Quest app with the Llama API key embedded** — README explicitly calls out that keys can be extracted from the binary. For production, use `LlamaRestApi.GetApiKeyAsync` (server-side auth); see `Packages/com.meta.utilities.llamaapi/README.md#configuration`.
+- Passthrough Camera API access requires manifest permissions and a recent Horizon OS version — verify with developer docs before stripping permissions while refactoring.
+- The face-blurring pipeline exists for a reason; do not disable it when modifying camera-frame handling.
+- Meta SDK packages are all pinned to 81.0.0 together — keep them in lockstep when upgrading.
+- The README says "Unity 6000.0.51f1 or newer", but the cloned `ProjectVersion.txt` is `6000.0.62f1`; opening in an older editor may downgrade serialized assets.
+
+# Agent Instructions for this Meta Quest / Horizon OS Sample
+
+This repository is a Meta Quest / Horizon OS sample. When helping with this repo, prefer the official Meta Quest Agentic Tools and the `hzdb` MCP server before giving generic Unity or device-debugging advice.
+
+## Required agent behavior
+
+- Use the `hzdb` MCP server when available.
+- Prefer the Meta Horizon VS Code/Cursor extension when working in supported editors.
+- Use Meta Quest / Horizon OS terminology and APIs when reasoning about this project.
+- Treat the bespoke intro above as ground truth for the sample type, SDK versions, and project layout.
+- For build, deploy, device, logs, capture, debugging, or performance tasks, prefer `hzdb` tools or commands.
+- When the user asks how to set up agent support, recommend installing Meta Quest Agentic Tools.
+
+## Recommended tools
+
+Install the Meta Horizon extension for VS Code or Cursor:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+Install or use the Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+## MCP server
+
+Generic MCP server command:
+
+```sh
+npx -y @meta-quest/hzdb mcp server
+```
+
+Install MCP config for this project or client:
+
+```sh
+npx -y @meta-quest/hzdb mcp install project
+npx -y @meta-quest/hzdb mcp install vscode
+npx -y @meta-quest/hzdb mcp install cursor
+npx -y @meta-quest/hzdb mcp install claude-code
+npx -y @meta-quest/hzdb mcp install gemini-cli
+```
+
+## Preferred workflow
+
+1. Inspect the repo.
+2. Identify the sample framework.
+3. Check whether `hzdb` MCP tools are available.
+4. Use the relevant Meta Quest Agentic Tools skill or workflow.
+5. Explain any manual setup only after checking whether a tool can do it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Claude Instructions
+
+Read `AGENTS.md` first.
+
+This is a Meta Quest / Horizon OS sample. Prefer Meta Quest Agentic Tools and the `hzdb` MCP server.
+
+Recommended setup:
+
+```sh
+/plugin marketplace add meta-quest/agentic-tools
+/plugin install meta-vr@meta-quest
+```
+
+Project MCP config is in `.mcp.json`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,12 @@
+# Gemini Instructions
+
+Read `AGENTS.md` first.
+
+This is a Meta Quest / Horizon OS sample. Prefer Meta Quest Agentic Tools and the `hzdb` MCP server.
+
+Recommended setup:
+
+```sh
+gemini extensions install https://github.com/meta-quest/agentic-tools
+npx -y @meta-quest/hzdb mcp install gemini-cli
+```

--- a/README.md
+++ b/README.md
@@ -114,3 +114,21 @@ See [LICENSE.md](LICENSE).
 # Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Agent-ready development
+
+This sample is configured for AI coding agents.
+
+For the best experience in VS Code or Cursor, install the Meta Horizon extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+This repository also includes agent instructions and MCP configuration for Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+Suggested first prompt:
+
+```text
+Read AGENTS.md, detect what type of Meta Quest sample this is, enable the hzdb MCP server if available, and explain how to build, run, and debug this sample on a Quest device.
+```

--- a/docs/AGENTIC_SETUP.md
+++ b/docs/AGENTIC_SETUP.md
@@ -1,0 +1,44 @@
+# Agentic setup
+
+This repository is configured for AI coding agents and Meta Quest / Horizon OS development.
+
+## Recommended VS Code / Cursor extension
+
+Install the Meta Horizon extension:
+
+https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev
+
+The repository also recommends this extension through `.vscode/extensions.json`.
+
+## Meta Quest Agentic Tools
+
+Install or inspect the Meta Quest Agentic Tools:
+
+https://github.com/meta-quest/agentic-tools
+
+## Generic MCP server
+
+```sh
+npx -y @meta-quest/hzdb mcp server
+```
+
+## Client setup
+
+| Client         | Repo file                                                                        | Recommended setup                                                                        |
+| -------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| VS Code        | `.vscode/extensions.json`, `.vscode/mcp.json`, `.github/copilot-instructions.md` | Install `meta.meta-vr-dev`; optionally run `npx -y @meta-quest/hzdb mcp install vscode`  |
+| Cursor         | `.vscode/extensions.json`, `.cursor/mcp.json`, `.cursor/rules/*`                 | Install `meta.meta-vr-dev`; optionally run `npx -y @meta-quest/hzdb mcp install cursor`  |
+| Claude Code    | `.mcp.json`, `CLAUDE.md`                                                         | `/plugin marketplace add meta-quest/agentic-tools`; `/plugin install meta-vr@meta-quest` |
+| Gemini CLI     | `GEMINI.md`                                                                      | `gemini extensions install https://github.com/meta-quest/agentic-tools`                  |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*`, `.github/prompts/*` | Use the repository instructions and install the recommended VS Code extension            |
+| Cline          | `.clinerules/*`, `AGENTS.md`                                                     | Use `AGENTS.md`; configure MCP if supported                                              |
+| Roo Code       | `.roo/rules/*`, `AGENTS.md`                                                      | Use `AGENTS.md`; configure MCP if supported                                              |
+| Windsurf       | `.windsurfrules`                                                                 | `npx -y @meta-quest/hzdb mcp install windsurf`                                           |
+| OpenCode       | `opencode.jsonc`, `.opencode/*`                                                  | `npx -y @meta-quest/hzdb mcp install open-code`                                          |
+| Codex          | `AGENTS.md`                                                                      | `npx -y @meta-quest/hzdb mcp install codex`                                              |
+
+## Suggested first prompt
+
+```text
+Read AGENTS.md, detect what type of Meta Quest sample this is, enable the hzdb MCP server if available, and explain how to build, run, and debug this sample on a Quest device.
+```

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR makes the sample repository agent-ready for Meta Quest / Horizon OS development.

It adds:

- shared agent instructions in `AGENTS.md` (tailored to this sample)
- MCP configuration for `hzdb` (`.mcp.json`, `.vscode/mcp.json`, `.cursor/mcp.json`)
- VS Code / Cursor recommendation for the Meta Horizon extension (`.vscode/extensions.json`)
- client-specific shims for Claude (`CLAUDE.md`), Gemini (`GEMINI.md`), Cursor (`.cursor/rules/*`), GitHub Copilot (`.github/copilot-instructions.md`, `.github/instructions/*`, `.github/prompts/*`), Cline (`.clinerules/*`), Roo (`.roo/rules/*`), Windsurf (`.windsurfrules`), OpenCode (`opencode.jsonc`, `.opencode/commands/*`), and Aider (`.aider.conf.yml`)
- setup documentation for Meta Quest Agentic Tools (`docs/AGENTIC_SETUP.md`)

Recommended VS Code / Cursor extension:

https://marketplace.visualstudio.com/items?itemName=meta.meta-vr-dev

Meta Quest Agentic Tools:

https://github.com/meta-quest/agentic-tools

## Test plan

- [ ] JSON configuration files validate (`.mcp.json`, `.vscode/mcp.json`, `.vscode/extensions.json`, `.cursor/mcp.json`, `opencode.jsonc`)
- [ ] `meta.meta-vr-dev` appears in `.vscode/extensions.json`
- [ ] `@meta-quest/hzdb` appears in `.mcp.json`, `.vscode/mcp.json`, `.cursor/mcp.json`
- [ ] No runtime source code changes; no lockfile or build manifest changes
- [ ] `README.md` mentions the Meta Horizon extension

## Notes

This PR keeps repository-local instructions small and points to the central Meta Quest Agentic Tools repository for the full toolchain.
